### PR TITLE
Initial feature branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle/
 /.yardoc
+/.idea
 /Gemfile.lock
 /_yardoc/
 /coverage/
@@ -10,3 +11,4 @@
 
 # rspec failure tracking
 .rspec_status
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ _your_app/config/initializers/bitly_client.rb_
 
 ```ruby
 Bitly::Client.configure do |config|
-  config.api_token = YOUR_OATH_TOKEN
+  config.api_token = YOUR_GENERIC_OATH_ACCESS_TOKEN
   config.api_url = BITLY_API_SHORTEN_URL # e.g. https://api-ssl.bitly.com/v4/shorten
 end
 ```
+
+> [Get a Bitly generic access token](https://dev.bitly.com/docs/getting-started/authentication)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Bitly::Client
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/bitly/client`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+A super simple, one-way client for using Bitly's API for shortening long URLs. This was created to support a legacy app on Ruby 1.9.3 and Rails 3.1 because many other shortening clients require Ruby 2.0+.
 
 ## Installation
 
@@ -22,7 +20,20 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+```ruby
+Bitly::Client.new("https://lyconic.com/2016/11/21/tips-hiring-quality-security-guards-officers/").shorten
+```
+
+## Config
+
+_your_app/config/initializers/bitly_client.rb_
+
+```ruby
+Bitly::Client.configure do |config|
+  config.api_token = YOUR_OATH_TOKEN
+  config.api_url = BITLY_API_SHORTEN_URL # e.g. https://api-ssl.bitly.com/v4/shorten
+end
+```
 
 ## Development
 
@@ -32,8 +43,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/afilbert/bitly-client.
-
+Bug reports and pull requests are welcome on GitHub at https://github.com/lyconic/bitly-client.
 
 ## License
 

--- a/bitly-client.gemspec
+++ b/bitly-client.gemspec
@@ -9,28 +9,19 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Aron Filbert"]
   spec.email         = ["afilbert@lyconic.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{Extremely simple one-way URL shortener client for bit.ly.}
+  spec.description   = spec.summary
+  spec.homepage      = "https://github.com/lyconic/bitly-client"
   spec.license       = "MIT"
-
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry", "=0.9.9"
+  spec.add_dependency "httparty", "0.10.2"
 end

--- a/lib/bitly/client.rb
+++ b/lib/bitly/client.rb
@@ -1,7 +1,17 @@
+require "bitly/client/connection"
+require "bitly/client/config"
+require "bitly/client/config_error"
 require "bitly/client/version"
 
 module Bitly
   module Client
-    # Your code goes here...
+    extend self
+
+    def shorten(long_url, api_token = nil)
+      if api_token.nil? && (configuration.nil? || configuration.api_token.nil?)
+        raise ConfigError.new "Please add Bitly::Client configuration to your app initializer"
+      end
+      Connection.new(long_url, api_token).shorten
+    end
   end
 end

--- a/lib/bitly/client/config.rb
+++ b/lib/bitly/client/config.rb
@@ -1,0 +1,21 @@
+module Bitly
+  module Client
+    class << self
+      attr_accessor :configuration
+
+      def configure
+        self.configuration ||= Config.new
+        yield(configuration)
+      end
+    end
+
+    class Config
+      attr_accessor :api_token
+      attr_accessor :api_url
+
+      def initialize
+        @api_url = "https://api-ssl.bitly.com/v4/shorten"
+      end
+    end
+  end
+end

--- a/lib/bitly/client/config_error.rb
+++ b/lib/bitly/client/config_error.rb
@@ -1,0 +1,6 @@
+module Bitly
+  module Client
+    class ConfigError < StandardError
+    end
+  end
+end

--- a/lib/bitly/client/connection.rb
+++ b/lib/bitly/client/connection.rb
@@ -1,6 +1,5 @@
 require "httparty"
 require "json"
-require "pry"
 
 module Bitly
   module Client

--- a/lib/bitly/client/connection.rb
+++ b/lib/bitly/client/connection.rb
@@ -1,0 +1,41 @@
+require "httparty"
+require "json"
+require "pry"
+
+module Bitly
+  module Client
+    class Connection
+      attr_accessor :api_token
+      attr_accessor :api_url
+      attr_accessor :long_url
+
+      def initialize(long_url, api_token = nil, api_url = nil)
+        @api_token = api_token || Bitly::Client.configuration.api_token
+        @api_url = api_url || Bitly::Client.configuration.api_url
+        @long_url = long_url
+      end
+
+      def shorten
+        @response = HTTParty.post(api_url, headers: headers, body: body)
+        if !@response.nil? && @response.success?
+          @response["link"]
+        end
+      end
+
+      private
+
+      def body
+        {
+          long_url: long_url
+        }.to_json
+      end
+
+      def headers
+        {
+          "Content-Type" => "application/json",
+          "Authorization" => "Bearer #{api_token}"
+        }
+      end
+    end
+  end
+end

--- a/spec/bitly/client/config_spec.rb
+++ b/spec/bitly/client/config_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "securerandom"
+
+RSpec.describe Bitly::Client::Config do
+  let(:api_token) { SecureRandom.urlsafe_base64 }
+  let(:api_url) { "https://api-ssl.bitly.com/v4/shorten" }
+
+  before(:each) do
+    Bitly::Client.configure do |config|
+      config.api_token = api_token
+      config.api_url = api_url
+    end
+  end
+
+  after(:each) do
+    Bitly::Client.configuration = nil
+  end
+
+  it "sets/gets an API token and URL" do
+    expect(Bitly::Client.configuration.api_token).to match api_token
+    expect(Bitly::Client.configuration.api_url).to match api_url
+  end
+end

--- a/spec/bitly/client/connection_spec.rb
+++ b/spec/bitly/client/connection_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe Bitly::Client::Connection do
+  let(:api_token) { SecureRandom.urlsafe_base64 }
+  let(:api_url) { "https://api-ssl.bitly.com/v4/shorten" }
+
+  let(:config_token) { SecureRandom.urlsafe_base64 }
+  let(:config_url) { "https://api-ssl.bitly.com/v3/shorten" }
+
+  let(:long_url) { "https://lyconic.com/2016/11/21/tips-hiring-quality-security-guards-officers/" }
+  let(:short_url) { "https://bit.ly/3d7N2vV" }
+
+  let(:response) { double("HTTParty::Response", :[] => short_url, success?: true) }
+
+  after(:all) do
+    Bitly::Client.configuration = nil
+  end
+
+  context "#new" do
+    it "initializes with optional parameters" do
+      subject = described_class.new(long_url, api_token, api_url)
+      expect(subject.api_token).to match api_token
+      expect(subject.api_url).to match api_url
+      expect(subject.long_url).to match long_url
+    end
+
+    it "initializes with default parameters" do
+      Bitly::Client.configure do |config|
+        config.api_token = config_token
+        config.api_url = config_url
+      end
+      subject = described_class.new(long_url)
+      expect(subject.api_token).to match config_token
+      expect(subject.api_url).to match config_url
+      expect(subject.long_url).to match long_url
+    end
+  end
+
+  context ".shorten" do
+    it "returns a shortened URL" do
+      allow(HTTParty).to receive(:post).and_return(response)
+      expect(described_class.new(long_url).shorten).to match short_url
+    end
+  end
+end

--- a/spec/bitly/client_spec.rb
+++ b/spec/bitly/client_spec.rb
@@ -2,10 +2,12 @@ require "spec_helper"
 
 RSpec.describe Bitly::Client do
   it "has a version number" do
-    expect(Bitly::Client::VERSION).not_to be nil
+    expect(described_class::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  context "#shorten" do
+    it "raises an exception if no API token available" do
+      expect { described_class.shorten("http://lyconic.com") }.to raise_error(Bitly::Client::ConfigError)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "bitly/client"
+require "pry"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
### Simple Interface One-way Bitly URL Shortener

PR introduces basic gem behavior.

Config in your initializer:

```
Bitly::Client.configure do |config|
  config.api_token = YOUR_OATH_TOKEN
  config.api_url = "https://api-ssl.bitly.com/v4/shorten"
end
```

Usage:

```
Bitly::Client.new("https://lyconic.com/2016/11/21/tips-hiring-quality-security-guards-officers/").shorten
```

[Read more here.](https://dev.bitly.com/docs/getting-started/authentication)