### PR TITLE
Change gem name to bitly-client-legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A super simple, one-way client for using Bitly's API for shortening long URLs. T
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'bitly-client'
+gem 'bitly-client-legacy'
 ```
 
 And then execute:
@@ -16,7 +16,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install bitly-client
+    $ gem install bitly-client-legacy
 
 ## Usage
 

--- a/bitly-client-legacy.gemspec
+++ b/bitly-client-legacy.gemspec
@@ -4,14 +4,14 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'bitly/client/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "bitly-client"
+  spec.name          = "bitly-client-legacy"
   spec.version       = Bitly::Client::VERSION
   spec.authors       = ["Aron Filbert"]
   spec.email         = ["afilbert@lyconic.com"]
 
   spec.summary       = %q{Extremely simple one-way URL shortener client for bit.ly.}
   spec.description   = spec.summary
-  spec.homepage      = "https://github.com/lyconic/bitly-client"
+  spec.homepage      = "https://github.com/lyconic/bitly-client-legacy"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
The available gem called `bitly-client` required faraday, which required Ruby version 2.0+

Renaming this gem so I can push to rubygems.org